### PR TITLE
[Front-end] - Criação do input do tipo date

### DIFF
--- a/src/components/Date/Date.stories.tsx
+++ b/src/components/Date/Date.stories.tsx
@@ -1,0 +1,40 @@
+import { Meta, StoryFn, StoryObj } from "@storybook/react";
+import { DateProps } from "./Date.types";
+import Date from "./Date";
+
+const meta = {
+  title: "Forms/Date",
+  component: Date,
+  argTypes: {
+    size: {
+      options: ["standard", "small"],
+      control: { type: "radio" },
+    },
+  },
+} satisfies Meta<typeof Date>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    name: "date",
+    label: "Usuário",
+  },
+};
+
+export const Required: Story = {
+  args: {
+    name: "date",
+    label: "Date obrigatório",
+    required: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    name: "date",
+    label: "Date desabilitado",
+    disabled: true,
+  },
+};

--- a/src/components/Date/Date.tsx
+++ b/src/components/Date/Date.tsx
@@ -1,0 +1,62 @@
+import { FC, useState, ChangeEvent } from "react";
+import clsx from "clsx";
+import { DateProps, DateSize } from "./Date.types";
+import * as Label from "@radix-ui/react-label";
+
+const Date: FC<DateProps> = ({
+  size = "standard",
+  label,
+  name,
+  disabled,
+  ...props
+}) => {
+  const [invalid, setInvalid] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const handleBlur = (event: ChangeEvent<HTMLInputElement>) => {
+    setInvalid(!event.target.checkValidity() || !event.target.value);
+    setErrorMessage(event.target.validationMessage || "");
+  };
+
+  const sizesDate: { [key in DateSize]: string } = {
+    standard: `w-full px-6 py-4 my-2`,
+    small: `flex w-1/4 px-4 py-4 my-2`,
+  };
+
+  const sizesLabel = {
+    standard: `text-base w-full`,
+    small: `text-sm`,
+  };
+
+  return (
+    <Label.Root
+      className={clsx(
+        disabled && "input-label-disabled",
+        "input-label",
+        sizesLabel[size]
+      )}
+      htmlFor={name}
+    >
+      {label}
+      <input
+        name={name}
+        type="date"
+        {...props}
+        className={clsx(
+          sizesDate[size],
+          invalid && "input-invalid",
+          "input-default"
+        )}
+        onBlur={handleBlur}
+        disabled={disabled}
+      />
+      {errorMessage && !disabled && (
+        <div className={"font-normal my-2 text-danger-01 text-sm"}>
+          {errorMessage}
+        </div>
+      )}
+    </Label.Root>
+  );
+};
+
+export default Date;

--- a/src/components/Date/Date.types.ts
+++ b/src/components/Date/Date.types.ts
@@ -1,0 +1,8 @@
+export type DateSize = "standard" | "small";
+
+export interface DateProps
+  extends Omit<React.HTMLProps<HTMLInputElement>, "size"> {
+  name: string;
+  size?: DateSize;
+  label?: string;
+}

--- a/src/components/Date/index.tsx
+++ b/src/components/Date/index.tsx
@@ -1,0 +1,2 @@
+export { default } from "./Date";
+export type { DateProps } from "./Date.types";


### PR DESCRIPTION
Obs: Foi acordado que este componente ainda não possuirá um dropdown com calendário customizado, pois ainda pende de confirmação com o time de UX se haverá ou não este dropdown.
Link do card: https://trello.com/c/16VxnKUF/96-criar-componente-de-input-do-tipo-date