### PR TITLE
feat: dashboard card profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@storybook/testing-library": "^0.0.14-next.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
+    "@types/jest": "^29.5.0",
     "@types/node": "18.13.0",
     "@types/node-fetch": "^2.6.2",
     "@types/react": "18.0.27",

--- a/src/components/DashboardCardProfile/DashboardCardProfile.stories.tsx
+++ b/src/components/DashboardCardProfile/DashboardCardProfile.stories.tsx
@@ -1,0 +1,34 @@
+import { StoryObj, Meta } from "@storybook/react";
+import DashboardCardProfile from "./DashboardCardProfile";
+
+const meta = {
+  title: "Data Display/DashboardCardProfile",
+  component: DashboardCardProfile,
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          background: "gray",
+          height: "35vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof DashboardCardProfile>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    name: "Ronald Richards",
+    job: "Software Engineer at Apple",
+    skills: ["Full-Stack", "Back-End", "Front-End"],
+    avatar: "https://via.placeholder.com/98",
+  },
+};

--- a/src/components/DashboardCardProfile/DashboardCardProfile.test.tsx
+++ b/src/components/DashboardCardProfile/DashboardCardProfile.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import DashboardCardProfile from "./DashboardCardProfile";
+import { Props } from "./DashboardCardProfile.types";
+import "@testing-library/jest-dom/extend-expect";
+
+describe("DashboardCardProfile", () => {
+  const props: Props = {
+    name: "Ronald Richards",
+    job: "Software Engineer at Apple",
+    skills: ["Frontend", "Backend", "DevOps"],
+    avatar: "/test.png",
+  };
+
+  it("renders name and job", () => {
+    render(<DashboardCardProfile {...props} />);
+    expect(screen.getByText(props.name)).toBeInTheDocument();
+    expect(screen.getByText(props.job)).toBeInTheDocument();
+  });
+
+  it("renders skills", () => {
+    render(<DashboardCardProfile {...props} />);
+    props.skills.forEach((skill) => {
+      expect(screen.getByText(skill)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/DashboardCardProfile/DashboardCardProfile.tsx
+++ b/src/components/DashboardCardProfile/DashboardCardProfile.tsx
@@ -1,0 +1,41 @@
+import Image from "next/image";
+import imgCard from "../../public/imgCard.png";
+import { Props } from "./DashboardCardProfile.types";
+import Chip from "../Chip";
+
+const DashboardCardProfile = ({
+  skills = ["Full-Stack", "Back-End", "Front-End"],
+  name,
+  job,
+  avatar,
+}: Props) => {
+  return (
+    <div className="p-4 flex justify-center items-center gap-4">
+      <div className="rounded-lg overflow-hidden w-24 h-24">
+        <Image
+          src={avatar ? avatar : imgCard}
+          alt="avatar profile"
+          width={98}
+          height={98}
+        />
+      </div>
+      <div>
+        <h1 className="text-3xl font-bold text-neutral-01 max-w-[320px] truncate">
+          {name}
+        </h1>
+        <p className="text-sm text-gray-01 max-w-[280px] truncate">{job}</p>
+        <div className="flex gap-2 mt-4 max-w-[260px] truncate">
+          {skills.map((skill) => {
+            return (
+              <Chip key={skill} variant="primary">
+                {skill}
+              </Chip>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DashboardCardProfile;

--- a/src/components/DashboardCardProfile/DashboardCardProfile.types.ts
+++ b/src/components/DashboardCardProfile/DashboardCardProfile.types.ts
@@ -1,0 +1,6 @@
+export type Props = {
+  name: string;
+  job: string;
+  skills: string[];
+  avatar?: string;
+};

--- a/src/components/DashboardCardProfile/index.tsx
+++ b/src/components/DashboardCardProfile/index.tsx
@@ -1,0 +1,2 @@
+export { default } from "./DashboardCardProfile";
+export type { Props } from "./DashboardCardProfile.types";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,5 +27,5 @@
     "src",
     "node_modules/@types"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "./cypress.config.ts", "cypress", "**/*.cy.tsx"]
 }


### PR DESCRIPTION
## Dashboard Card Profile

Essa PR implementa o componente DashboardCardProfile, permitindo que ele receba os dados por Props.

This PR implements the DashboardCardProfile component, allowing it to receive data through Props.

- [x] test unitário
- [x] storybook do component 

![profileTask](https://user-images.githubusercontent.com/110191259/230539591-a8c9d0b2-2291-4def-9140-1e57297c05d8.jpg)
![storybookProfile](https://user-images.githubusercontent.com/110191259/230539595-41c807a2-71af-4126-8455-cb3b61772767.jpg)
![testProfile](https://user-images.githubusercontent.com/110191259/230539598-fc9d5290-d907-4270-8623-0b6564b63afb.jpg)
