### PR TITLE
fix: resizing scheduling pop-up

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -14,7 +14,7 @@ const Modal = ({
       <Dialog.Trigger asChild>{openModalComponent}</Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Overlay className="bg-blackA9 data-[state=open]:animate-overlayShow fixed inset-0" />
-        <Dialog.Content className="text-center py-6 text-secondary-03 z-50 rounded-lg bg-scroll overflow-y-auto bg-neutral-01 dark:bg-secondary-02 fixed top-[50%] left-[50%] max-h-[90vh] w-auto   translate-x-[-50%] translate-y-[-50%]  shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] border border-neutral-02 ">
+        <Dialog.Content className="w-auto text-center py-6 text-secondary-03 z-50 rounded-lg bg-scroll overflow-y-auto bg-neutral-01 dark:bg-secondary-02 fixed top-[50%] left-[50%] max-h-[90vh] translate-x-[-50%] translate-y-[-50%]  shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] border border-neutral-02">
           {children}
           <Dialog.Close asChild>
             <div>

--- a/src/components/ScheduleMentorshipModal/ScheduleMentorhipModal.tsx
+++ b/src/components/ScheduleMentorshipModal/ScheduleMentorhipModal.tsx
@@ -264,13 +264,13 @@ export const ScheduleMentorshipModal = ({
         )}
         {currentStep === 2 && (
           <>
-            <div className="min-w-[280px]">
+            <div className="w-full min-w-[280px] lg:w-[448px] md:w-[448px] sm:w-[361px]">
               <hr className="text-gray-02 w-full mt-16" />
               <h2 className="mt-16 font-bold text-2xl text-secondary-02">
                 Mentoria de 30 minutos
               </h2>
               <p className="mt-6 text-secondary-02">
-                <span className="font-bold text-secondary-02">Horário:</span>{" "}
+                <span className="font-bold">Horário:</span>{" "}
                 {selectedStartTime.replace(":", "h")} até as{" "}
                 {selectedEndTime.replace(":", "h")}
               </p>


### PR DESCRIPTION
Nesta tarefa eu redimensionei o pop-up para que os steps ficassem do mesmo tamanho que o da etapa anterior e também removi a cor do `<span>Horário:</span>` pois no dark-mode estava da mesma cor do background.
Antes:
![image](https://github.com/Mentor-Cycle/mentor-cycle-fe/assets/103855358/572814b8-e281-4a6d-9287-4f9556c71e25)

Depois: 
![image](https://github.com/Mentor-Cycle/mentor-cycle-fe/assets/103855358/c4e25ba5-f591-4bc2-b974-87a9edf0066e)
