### PR TITLE
Refactor signup Layout

### DIFF
--- a/src/components/CenteredContainer/component.tsx
+++ b/src/components/CenteredContainer/component.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+interface ICenteredContainer extends React.ComponentProps<"div"> {
+  children: React.ReactNode;
+}
+
+export function CenteredContainer({
+  children,
+  className = "",
+  ...rest
+}: ICenteredContainer) {
+  return (
+    <div className={"max-w-7xl w-full mx-auto" + " " + className} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/CenteredContainer/index.ts
+++ b/src/components/CenteredContainer/index.ts
@@ -1,0 +1,1 @@
+export * from "./component";

--- a/src/components/FormSteps/FormSteps.tsx
+++ b/src/components/FormSteps/FormSteps.tsx
@@ -118,7 +118,7 @@ const FormSteps: React.FC = () => {
         <Button
           className={clsx(
             currentStep === 1 ? "hidden" : "",
-            "order-last sm:order-first max-w-[328px]"
+            "order-last sm:order-first"
           )}
           variant="secondary"
           onClick={() => updateCurrentStep((currentStep || 2) - 1)}
@@ -129,7 +129,7 @@ const FormSteps: React.FC = () => {
           tabIndex={2}
           className={clsx(
             currentStep === 1 ? "" : "hidden",
-            "order-last sm:order-first max-w-[328px]"
+            "order-last sm:order-first"
           )}
           variant="secondary"
           onClick={() => router.push("/signup/plan")}
@@ -138,7 +138,7 @@ const FormSteps: React.FC = () => {
         </Button>
         <Button
           tabIndex={0}
-          className={clsx("max-w-[328px]", "order-first sm:order-last")}
+          className={clsx("", "order-first sm:order-last")}
           isLoading={isSubmitting}
           onClick={() => {
             if (currentStep === 3) {

--- a/src/components/FormSteps/PersonalInformation.tsx
+++ b/src/components/FormSteps/PersonalInformation.tsx
@@ -125,7 +125,7 @@ const PersonalInformation = () => {
         />
         <InputBirthday
           name="birthDate"
-          label="Aniversário"
+          label="Data de Nascimento"
           placeholder="DD/MM/AAAA"
         />
       </div>

--- a/src/components/Stepper/Stepper.tsx
+++ b/src/components/Stepper/Stepper.tsx
@@ -16,7 +16,7 @@ const Stepper: React.FC<StepperProps> = ({
   };
 
   const containerClasses = clsx(
-    "flex justify-between items-center mb-4 w-full max-w-2xl"
+    "flex justify-between items-center w-full max-w-2xl"
   );
   const stepClasses = clsx(
     " flex items-center justify-center relative  text-neutral-01 transition-colors duration-500 z-10"

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -12,6 +12,7 @@ export const PUBLIC_ROUTES = [
 export const ROUTES_WITHOUT_HEADER = [
   "/signin",
   "/signup/register",
+  "/signup/plan",
   "/request-change-password",
   "/",
   "/landing-page",

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -11,6 +11,7 @@ export const PUBLIC_ROUTES = [
 ];
 export const ROUTES_WITHOUT_HEADER = [
   "/signin",
+  "/signup/register",
   "/request-change-password",
   "/",
   "/landing-page",

--- a/src/pages/signup/register.tsx
+++ b/src/pages/signup/register.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
+import { CenteredContainer } from "@components/CenteredContainer";
 import FormSteps from "@components/FormSteps";
 import Stepper from "@components/Stepper/Stepper";
 import StepperVertical from "@components/StepperVertical";
@@ -9,36 +10,40 @@ const Register = () => {
 
   return (
     <main className="min-h-[130vh] flex flex-col">
-      <section className="border-opacity-30 border-t border-b border-gray-02 w-full py-[52px] sm:justify-between 2xl:justify-around sm:px-8 lg:px-20 2xl:px-36 hidden sm:flex">
-        <Stepper
-          steps={[1, 2, 3]}
-          currentStep={currentStep}
-          className="hidden sm:block"
-          size="regular"
-        />
-        <div className="max-w-xs">
-          <h3 className="font-bold text-xl">Status do seu registro</h3>
-          <p className="text-gray-02 text-xs w-3/4">
-            Acompanhe em qual parte do registro você se encontra
-          </p>
-        </div>
-      </section>
-      <section className="w-full flex flex-col lg:flex-row justify-between 2xl:justify-evenly md:mt-12 lg:px-20 2xl:px-36 mb-20">
-        <aside className="pt-10 md:pt-0">
-          <h2 className="text-primary-05 text-3xl font-semibold text-center lg:text-start">
-            Registre-se aqui!
-          </h2>
-          <p className="text-gray-04 text-sm mt-2 mb-12 px-4 sm:px-0 text-center lg:w-3/4 lg:text-start">
-            Preencha os campos para criar a sua conta e acessar a plataforma!
-          </p>
-          <StepperVertical
+      <section className="h-28 border-b border-gray-02 hidden sm:flex">
+        <CenteredContainer className="flex items-center justify-between px-8 sm:px-12">
+          <Stepper
+            steps={[1, 2, 3]}
             currentStep={currentStep}
-            className="hidden lg:block"
+            className="hidden sm:block"
+            size="regular"
           />
-        </aside>
-        <section className="max-w-2xl w-full m-auto lg:m-0 mb-24 px-4">
-          <FormSteps />
-        </section>
+          <div className="max-w-xs">
+            <h3 className="font-bold text-xl">Status do seu registro</h3>
+            <p className="text-gray-02 text-xs w-3/4 md:block hidden">
+              Acompanhe em qual parte do registro você se encontra
+            </p>
+          </div>
+        </CenteredContainer>
+      </section>
+      <section className="">
+        <CenteredContainer className="flex flex-col lg:flex-row justify-between px-8 sm:px-12 mt-12">
+          <aside className="">
+            <h2 className="text-primary-05 text-3xl font-semibold text-center lg:text-start">
+              Registre-se aqui!
+            </h2>
+            <p className="text-gray-04 text-sm mt-2 mb-12 px-4 sm:px-0 text-center lg:w-3/4 lg:text-start">
+              Preencha os campos para criar a sua conta e acessar a plataforma!
+            </p>
+            <StepperVertical
+              currentStep={currentStep}
+              className="hidden lg:block"
+            />
+          </aside>
+          <section className="w-full m-auto lg:m-0 mb-24 lg:max-w-none max-w-[48rem]">
+            <FormSteps />
+          </section>
+        </CenteredContainer>
       </section>
     </main>
   );

--- a/src/utils/removeTypename.ts
+++ b/src/utils/removeTypename.ts
@@ -1,0 +1,6 @@
+export function removeTypenameProperty<T extends { __typename: string }>(
+  objectWithTypenameProperty: T
+): Omit<T, "__typename"> {
+  const { __typename, ...objectWithoutTypename } = objectWithTypenameProperty;
+  return objectWithoutTypename;
+}


### PR DESCRIPTION
## refactor: switch lazy query to regular query && remove unnecessary useEffect

* Refatorei a query `GET_ME` do `Header.tsx` para uma versão mais enxuta e performática.
* Removi `errorMessages` dentro do `Header.tsx` porque aquelas mensagens de erros são de desenvolvimento, e não devem ser mostradas daquela forma pra UI.
* Criei um helper que recebe um objeto com `__typename` e retorna o mesmo objeto sem `__typename`.

---

## fix: remove header when in register page

* removi o header da página de signup, no formulário, resolvendo o erro de `Forbidden Resource`

---

## fix: change "Aniversário" to "Data de Nascimento"

* No formulário de registro, troquei aniversário por data de nascimento.
* Removi o header  da página de signup, na hora de escolher entre mentor e mentorado.

---

## fix: create CenteredContainer and fix signup page layout

* Consertei o layout do formulário, não estava seguindo um padrão de max-width
* Criei o componente `CenteredContainer` que centraliza e padroniza o conteúdo do site.
Pra ser usado, ele precisa ser filho de uma tag que tenha `width` total (naturalmente tem 100vw)
* Consertei o design de alguns botões pra ficar harmônico com o restante

Se reparar na esquerda, o Stepper, a logo e o letreiro não ficam alinhados.

### Antigo
![wrong-form-layout](https://github.com/Mentor-Cycle/mentor-cycle-fe/assets/121525239/a05bb12e-5121-4828-b06a-a084e0376d6d)

### Novo
![right-form-layout](https://github.com/Mentor-Cycle/mentor-cycle-fe/assets/121525239/9fbd2d51-72a1-4db8-a806-030533fa6131)

