### PR TITLE
feat: create small stepper for schedule mentoring

### DIFF
--- a/src/components/ScheduleMentorshipModal/ScheduleMentorhipModal.tsx
+++ b/src/components/ScheduleMentorshipModal/ScheduleMentorhipModal.tsx
@@ -16,6 +16,7 @@ import { useTypedQuery } from "@hooks/useTypedQuery";
 import { queriesIndex as api } from "services/apollo/queries/queries.index";
 import { TGET_AVAILABILITIES_queryDataSchema as TUserAvailability } from "services/apollo/queries/queries-properties";
 import { TStepButtons } from "@components/ScheduleMentorshipModal/ScheduleMentorhipModal.types";
+import StepperSmall from "@components/Stepper/StepperSmall";
 
 export const ScheduleMentorshipModal = ({
   open,
@@ -287,7 +288,7 @@ export const ScheduleMentorshipModal = ({
             </p>
           </>
         )}
-        <Stepper size="small" steps={[1, 2, 3]} currentStep={currentStep} />
+        <StepperSmall steps={[1, 2, 3]} currentStep={currentStep} />
         {currentStep === 1 && (
           <>
             <div className="mt-10">

--- a/src/components/Stepper/StepperSmall.tsx
+++ b/src/components/Stepper/StepperSmall.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+interface StepperSmallProps {
+  steps: number[];
+  currentStep: number;
+}
+
+const StepperSmall: React.FC<StepperSmallProps> = ({
+  steps = [1, 2, 3],
+  currentStep,
+}) => {
+  const totalSteps = steps.length;
+
+  return (
+    <div className="flex justify-between w-full">
+      {steps.map((step, index) => (
+        <React.Fragment key={index}>
+          <div
+            className={`w-[60px] min-w-[60px] h-[20px] flex justify-center items-center rounded-md text-white 
+            ${step <= currentStep ? "bg-primary-03" : "bg-gray-03"}`}
+          >
+            <span className="text-neutral-03 text-xs">{step}</span>
+          </div>
+          {index < totalSteps - 1 && (
+            <div
+              className={`w-full h-[2px] my-auto 
+              ${step < currentStep ? "bg-primary-03" : "bg-gray-03"}`}
+            ></div>
+          )}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+};
+
+export default StepperSmall;


### PR DESCRIPTION
Create a new, reduced-size stepper to fix the width bug that the old component contains.

![alinhamento_steppers](https://github.com/Mentor-Cycle/mentor-cycle-fe/assets/110191259/da065e46-bda6-41d4-b0fe-a84842438bc3)
