### PR TITLE
fix: text dark mode scheduling mentoring

### DIFF
--- a/src/components/ScheduleMentorshipModal/ScheduleMentorhipModal.tsx
+++ b/src/components/ScheduleMentorshipModal/ScheduleMentorhipModal.tsx
@@ -331,7 +331,9 @@ export const ScheduleMentorshipModal = ({
                 Mentoria de 30 minutos
               </h2>
               <p className="mt-6 text-secondary-02">
-                <span className="font-bold text-secondary-02">Horário:</span>{" "}
+                <span className="font-bold text-secondary-02 dark:text-neutral-03">
+                  Horário:
+                </span>{" "}
                 {selectedStartTime.replace(":", "h")} até as{" "}
                 {selectedEndTime.replace(":", "h")}
               </p>


### PR DESCRIPTION
fix: text dark mode scheduling mentoring


![dark-mode-scheduling](https://github.com/Mentor-Cycle/mentor-cycle-fe/assets/110191259/4939a4af-88c6-4a13-b661-22bc6980b9e6)
