### PR TITLE
feat: add skeleton card profile

### DIFF
--- a/src/components/Modal/ModalScheduleMentorship/ScheduleMentorhipModal.tsx
+++ b/src/components/Modal/ModalScheduleMentorship/ScheduleMentorhipModal.tsx
@@ -46,7 +46,7 @@ const ScheduleMentorshipModal = () => {
     loading: loadingMentor,
     error: errorMentor,
   } = useMentorProfile(id as string, {
-    skip: !id,
+    skip: !id || !SCHEDULE_MENTORSHIP_MODAL,
   });
   if (errorMentor?.error) console.log("errorMentor", errorMentor);
 
@@ -57,7 +57,7 @@ const ScheduleMentorshipModal = () => {
       learnerId: !user.isMentor ? user.id : null,
       mentorId: user.isMentor ? user.id : null,
     },
-    skip: !user.isLogged,
+    skip: !user.isLogged || !SCHEDULE_MENTORSHIP_MODAL,
   });
 
   const stepButtons: TStepButtons = {
@@ -246,15 +246,6 @@ const ScheduleMentorshipModal = () => {
   useEffect(() => {
     setConvertedDaysAndTimes([...new Set(daysAndTimes[daySelected])]);
   }, [daySelected, daysAndTimes]);
-
-  if (loadingMentor)
-    return (
-      <>
-        <div className="min-h-screen flex justify-center items-center">
-          <Spinner />
-        </div>
-      </>
-    );
 
   return (
     <Modal open={SCHEDULE_MENTORSHIP_MODAL} onOpenChange={() => resetStates()}>

--- a/src/components/Skeleton/Cards/SkeletonCardProfile.tsx
+++ b/src/components/Skeleton/Cards/SkeletonCardProfile.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import Skeleton from "../Skeleton";
+
+const SkeletonCardProfile = () => {
+  return (
+    <div className="min-h-[485px] max-w-[390px] sm:min-w-[280px] px-11 py-6 border w-full border-gray-03/30 rounded-lg shadow-sm shadow-gray-03 hover:opacity-90 transition-all">
+      <div className="absolute right-2 top-2">
+        <Skeleton className="w-12 h-4" />
+      </div>
+      <div>
+        <Skeleton className="rounded-lg w-22 h-22" />
+        <Skeleton className="h-6 mt-4 w-60" />
+        <Skeleton className="h-4 mt-2 w-40" />
+        <Skeleton className="h-3 mt-1 w-28" />
+      </div>
+      <div className="relative">
+        <div className="flex gap-2 mt-2 rounded-lg">
+          <Skeleton className="w-20 h-6" />
+          <Skeleton className="w-28 h-6" />
+          <Skeleton className="w-24 h-6" />
+        </div>
+        <Skeleton className="flex w-full justify-end mt-2 px-2 max-w-[270px]" />
+      </div>
+      <div className="mt-8">
+        <Skeleton className="h-24 mb-8" />
+        <Skeleton className="w-24 h-10" />
+      </div>
+    </div>
+  );
+};
+
+export default SkeletonCardProfile;

--- a/src/pages/mentors/mentors.tsx
+++ b/src/pages/mentors/mentors.tsx
@@ -2,6 +2,7 @@ import CardProfile from "@components/CardProfile";
 import Input from "@components/Input/Input";
 import SelectSkills from "@components/MultiSelect/SelectSkills";
 import TimeSelect from "@components/MultiSelect/TimeSelect";
+import SkeletonCardProfile from "@components/Skeleton/Cards/SkeletonCardProfile";
 import Spinner from "@components/Spinner";
 import { useTypedQuery } from "@hooks/useTypedQuery";
 import { useUser } from "@hooks/useUser";
@@ -128,6 +129,10 @@ const Mentors: NextPage = () => {
     );
   }
 
+  const skeletonArray = Array.from({ length: pageSize }, (_, index) => (
+    <SkeletonCardProfile key={index} />
+  ));
+
   return (
     <>
       <main className="min-h-screen xs:container m-auto mt-16 p-2 overflow-auto mb-5">
@@ -159,15 +164,15 @@ const Mentors: NextPage = () => {
             />
           </div>
         </div>
-        {loadingMentor && mentors.length === 0 ? (
-          <div className="min-h-screen flex justify-center items-center">
-            <Spinner size={50} />
+        {loadingMentor ? (
+          <div className="min-h-screen overflow-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 m-auto items-center sm:items-start justify-center sm:justify-between gap-4 mt-8 justify-items-center">
+            {skeletonArray}
           </div>
         ) : (
           <div>
             <InfiniteScroll
               dataLength={mentors.length}
-              loader={<Spinner size={50} />}
+              loader={<Spinner size={18} />}
               next={handleLoadMore}
               hasMore={mentors.length >= pageSize}
               className="min-h-screen overflow-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 m-auto items-center sm:items-start justify-center sm:justify-between gap-4 mt-8 justify-items-center"


### PR DESCRIPTION
Replaced the loading spinner with a loading skeleton for the profile card.

![skeleton-card-profile](https://github.com/Mentor-Cycle/mentor-cycle-fe/assets/110191259/23053975-e3ef-40b6-a82c-7000f974712f)
